### PR TITLE
feat: Add water meter support and enhance configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ Smartmeter P1 Port → SmartyReader Board → ESP8266/ESP32
 globals:
   - id: power_consumption_buffer
     type: double[90]  # Adjust size: 90 = 15min, 180 = 30min
+
+### M-Bus Channel Configuration
+By default, the DSMR standard assigns gas meters to M-Bus channel 1 and water meters to channel 2. These configurations are now explicitly defined in the `.yaml` files:
+```yaml
+dsmr:
+  gas_mbus_id: 1
+  water_mbus_id: 2
+```
+If you have a non-standard setup, such as **only a water meter connected to channel 1**, you can easily adjust the configuration. To do this, simply set the `gas_mbus_id` to a different, unused channel (e.g., 0) and change the `water_mbus_id` to 1.
+
+**Example for a water-only setup on channel 1:**
+```yaml
+dsmr:
+  gas_mbus_id: 0   # Disable gas monitoring
+  water_mbus_id: 1 # Assign water meter to channel 1
+```
 ```
 
 ## 📡 **MQTT Last Will and Testament (LWT)**

--- a/enhanced_weigu_smartyreader.yaml
+++ b/enhanced_weigu_smartyreader.yaml
@@ -138,6 +138,8 @@ dsmr:
   id: dsmr_instance
   decryption_key: !secret weigu_dsmr_key
   max_telegram_length: 1800
+  gas_mbus_id: 1
+  water_mbus_id: 2
 
 # Optional: Status LED indication
 #status_led:

--- a/enhanced_weigu_smartyreader_mqtt.yaml
+++ b/enhanced_weigu_smartyreader_mqtt.yaml
@@ -153,6 +153,8 @@ dsmr:
   id: dsmr_instance
   decryption_key: !secret weigu_dsmr_key
   max_telegram_length: 1800
+  gas_mbus_id: 1
+  water_mbus_id: 2
 
 # Comprehensive sensor configuration
 sensor:


### PR DESCRIPTION
This commit introduces several enhancements to the ESPHome smart meter configurations, making them more flexible and feature-rich.

1.  **Adds Water Meter Support:**
    *   Both `enhanced_weigu_smartyreader.yaml` and `enhanced_weigu_smartyreader_mqtt.yaml` now support water consumption monitoring.
    *   A `water_delivered` sensor has been added to the DSMR component.
    *   A `water_consumed_today` template sensor provides daily water usage statistics, with a midnight reset mechanism.

2.  **Adds Secondary Meter Detection:**
    *   A `secondary_meter_type` text sensor has been added to both configurations to automatically detect and report whether a 'Gas' or 'Water' meter is connected based on which sensor receives data.

3.  **Exposes M-Bus Channel IDs:**
    *   The `gas_mbus_id` and `water_mbus_id` are now explicitly defined in both configuration files to allow users to easily configure non-standard setups (e.g., a water meter on channel 1).

4.  **Optimizes MQTT Configuration for RAM:**
    *   The `enhanced_weigu_smartyreader_mqtt.yaml` file has been optimized to reduce memory usage by disabling the captive portal, per-phase solar sensors, and changing the power buffer data type to `float`.

5.  **Standardizes MQTT Log Levels:**
    *   The logger configuration in the MQTT file has been updated to ensure consistent log levels across components.

6.  **Updates Documentation:**
    *   The `README.md` has been updated to reflect all new features, optimizations, and M-Bus configuration instructions.