### PR TITLE
Refactor YAMLs and README for novice-friendly setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,48 +113,113 @@ This project also preserves the features and spirit of the original Arduino-base
 - Device uptime and ESPHome version
 - Last update timestamps
 
-## ⚙️ Installation Instructions
+## ⚙️ Installation Instructions for Novice Users
 
-### 1. Choose Your Configuration
-```bash
-# For Home Assistant users (recommended)
-cp enhanced_weigu_smartyreader.yaml your_device_name.yaml
+This guide will walk you through setting up your SmartyReader from scratch using ESPHome.
 
-# For MQTT users or mixed environments
-cp enhanced_weigu_smartyreader_mqtt.yaml your_device_name.yaml
+### Step 1: Create a New Device in ESPHome
 
-# For testing and debugging
-cp smartyreader_test_mode.yaml your_device_name.yaml
-```
+1.  Open your **ESPHome Dashboard**.
+2.  Click the **"+ NEW DEVICE"** button.
+3.  Give your device a name (e.g., `smartyreader`).
+4.  **Important:** Select the correct device type for your hardware.
+    *   For the **WeiGu SmartyReader**, the recommended board is **"WEMOS D1 mini Pro"**.
+    *   For other boards like the **Slimmelezer**, choose **"Generic ESP8266"** or the specific board model you are using.
+5.  ESPHome will create a basic configuration file for you. Click **"EDIT"** to open it.
 
-### 2. Configure Secrets
-```bash
-# Copy template and edit with your values
-cp secrets_template.yaml secrets.yaml
-# Edit secrets.yaml with your WiFi, keys, etc.
-```
+Your new configuration file will look something like this. **Notice that ESPHome has already created unique keys for the `api` and `ota` sections.**
 
-### 3. Customize Device Settings
-Edit your chosen configuration file:
 ```yaml
-# Update device names
-substitutions:
-  device_name: your_smartyreader_name
-  friendly_name: "Your SmartyReader Name"
-  
-# Update DSMR key (Luxembourg smartmeter)
-dsmr:
-  decryption_key: !secret your_dsmr_key
+esphome:
+  name: smartyreader
+  friendly_name: smartyreader
+
+esp8266:
+  board: d1_mini_pro
+
+# Enable logging
+logger:
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: "ABCDE12345........................"
+
+ota:
+  password: "YOUR_OTA_PASSWORD"
+
+wifi:
+  ssid: "YourWiFi_SSID"
+  password: "YourWiFi_Password"
+
+# ... etc.
 ```
 
-### 4. Flash to Device
-```bash
-# Compile and upload
-esphome run your_device_name.yaml
+**Do not change this base configuration.** It has been generated specifically for your device and its security keys.
 
-# Or compile only
-esphome compile your_device_name.yaml
+### Step 2: Add the SmartyReader Configuration Snippet
+
+1.  Decide which version you want to use:
+    *   `enhanced_weigu_smartyreader.yaml`: For direct integration with Home Assistant (recommended for most users).
+    *   `enhanced_weigu_smartyreader_mqtt.yaml`: For integration via MQTT.
+
+2.  Open the chosen file from this repository and **copy its entire content**.
+
+3.  Go back to the configuration file for your new device in the ESPHome editor.
+
+4.  **Paste the copied content at the very end of the file.**
+
+Your final file should be structured like this:
+```yaml
+# (Your original configuration from Step 1 is here)
+esphome:
+  name: smartyreader
+# ... etc ...
+wifi:
+  ssid: "YourWiFi_SSID"
+  password: "YourWiFi_Password"
+
+# ===================================================================
+# WeiGu SmartyReader Enhanced - ESPHome Configuration Snippet
+# (The content you just pasted starts here)
+# ===================================================================
+uart:
+  id: uart_bus
+# ... and the rest of the snippet ...
 ```
+
+### Step 3: Configure Your Secrets
+
+Your SmartyReader needs secrets like your WiFi password and DSMR key to function.
+
+1.  In the ESPHome dashboard, find your `secrets.yaml` file. If it doesn't exist, create one.
+2.  Copy the contents of the `secrets_template.yaml` file from this repository and paste them into your `secrets.yaml`.
+3.  Update the values with your own information. At a minimum, you will need to provide:
+    *   `wifi_ssid` and `wifi_password`
+    *   `weigu_dsmr_key` (This is the 32-character key from your utility provider for Luxembourg meters).
+
+**Note on Static IP:** The `secrets_template.yaml` includes a commented-out section for a static IP address. This is an **advanced feature**. Most users should leave this section commented out and allow their device to get an IP address automatically via DHCP.
+
+An example `secrets.yaml` for a typical user might look like this:
+```yaml
+# WiFi Configuration
+wifi_ssid: "MyHomeWiFi"
+wifi_password: "MySuperSecretPassword"
+
+# DSMR Decryption Key (Luxembourg smartmeter)
+# Replace with your actual 32-character hex key
+weigu_dsmr_key: "AEBD21B769A6D13C0DF064E383682EFF"
+
+# ... other secrets as needed ...
+```
+
+### Step 4: Install and Start Your Device
+
+1.  In the ESPHome editor, click **"SAVE"** and then **"INSTALL"**.
+2.  Choose the method to flash the firmware to your device (e.g., "Plug into this computer").
+3.  Follow the on-screen instructions.
+
+Once installed, your SmartyReader will connect to your network and should automatically appear as a new device in Home Assistant (if you are using the native API).
 
 ## 🔧 Hardware Requirements
 

--- a/enhanced_weigu_smartyreader.yaml
+++ b/enhanced_weigu_smartyreader.yaml
@@ -1,45 +1,16 @@
-esphome:
-  name: weigu_smartyreader_enhanced
-  friendly_name: WeiGu SmartyReader Enhanced
-
-esp8266:
-  board: d1_mini_pro
-
-# Enable logging
-logger:
-  baud_rate: 0
-  level: INFO
-  # Optional: Enable UART logging to D4 for debugging (like Arduino version)
-  # hardware_uart: UART1  # DISABLED: Conflicts with status LED on D4 (GPIO2)
-
-# Enable Home Assistant API
-api:
-  encryption:
-    key: !secret weigu_api_key
-
-ota:
-- platform: esphome
-  password: !secret weigu_ota_password
-
-# Enhanced WiFi configuration with static IP option
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  
-  # Optional static IP configuration
-  manual_ip:
-    static_ip: !secret static_ip
-    gateway: !secret gateway_ip
-    subnet: !secret subnet_mask
-    dns1: !secret dns1
-    dns2: 8.8.8.8
-
-  # Fallback hotspot (captive portal) DISABLED to save RAM.
-  # ap:
-  #   ssid: !secret weigu_ap_ssid
-  #   password: !secret weigu_ap_password
-
-# captive_portal:
+# ===================================================================
+# WeiGu SmartyReader Enhanced - ESPHome Configuration Snippet
+#
+# HOW TO USE:
+# 1. Create a new device in your ESPHome dashboard.
+# 2. In the configuration file for your new device, verify the
+#    'esphome', 'esp8266', 'logger', 'api', 'ota', and 'wifi'
+#    sections are correct for your hardware and network.
+# 3. Copy the entire content of THIS file.
+# 4. Paste it at the END of your new device's configuration file.
+# 5. Configure your 'secrets.yaml' file with the necessary
+#    values (like weigu_dsmr_key).
+# ===================================================================
 
 # Enhanced UART configuration
 uart:

--- a/enhanced_weigu_smartyreader_mqtt.yaml
+++ b/enhanced_weigu_smartyreader_mqtt.yaml
@@ -1,47 +1,21 @@
-# Enhanced SmartyReader with MQTT support (in addition to Home Assistant API)
-# This version includes MQTT publishing similar to the Arduino version
+# ===================================================================
+# WeiGu SmartyReader MQTT Enhanced - ESPHome Configuration Snippet
+#
+# HOW TO USE:
+# 1. Create a new device in your ESPHome dashboard.
+# 2. In the configuration file for your new device, verify the
+#    'esphome', 'esp8266', 'logger', 'api', 'ota', and 'wifi'
+#    sections are correct for your hardware and network.
+# 3. Copy the entire content of THIS file.
+# 4. Paste it at the END of your new device's configuration file.
+# 5. Configure your 'secrets.yaml' file with the necessary
+#    values (like weigu_dsmr_key, mqtt_broker, etc.).
+# ===================================================================
 
 substitutions:
   device_name: weigu_smartyreader_mqtt
   friendly_name: "WeiGu SmartyReader MQTT Enhanced"
   mqtt_topic_prefix: "lamsmarty"
-  
-esphome:
-  name: ${device_name}
-  friendly_name: ${friendly_name}
-
-esp8266:
-  board: d1_mini_pro
-
-# Enable logging with optional UDP output (like Arduino version)
-logger:
-  baud_rate: 0
-  level: INFO
-  # Enable UDP logging for debugging (like original Arduino project)
-  logs:
-    mqtt: INFO
-    sensor: INFO
-
-# Enable Home Assistant API
-api:
-  encryption:
-    key: !secret weigu_api_key
-
-ota:
-- platform: esphome
-  password: !secret weigu_ota_password
-
-# WiFi configuration
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-
-  # Fallback hotspot (captive portal) DISABLED to save RAM.
-  # ap:
-  #   ssid: !secret weigu_ap_ssid
-  #   password: !secret weigu_ap_password
-
-# captive_portal:
 
 # UART for smartmeter
 uart:

--- a/secrets_template.yaml
+++ b/secrets_template.yaml
@@ -5,19 +5,14 @@
 wifi_ssid: "your_wifi_ssid"
 wifi_password: "your_wifi_password"
 
-# Optional Static IP Configuration (comment out if using DHCP)
-static_ip: "192.168.1.100"
-gateway_ip: "192.168.1.1" 
-subnet_mask: "255.255.255.0"
-dns1: "192.168.1.1"
-
-# Access Point Configuration (fallback)
-weigu_ap_ssid: "SmartyReader-Fallback"
-weigu_ap_password: "smartyreader123"
-
-# ESPHome API and OTA
-weigu_api_key: "your_32_character_api_encryption_key_here"
-weigu_ota_password: "your_ota_password"
+# Optional Static IP Configuration (ADVANCED)
+# Most users should leave this section commented out to use DHCP.
+# Only uncomment and configure these values if you have a specific need for a
+# static IP and have also enabled the 'manual_ip' block in your main YAML file.
+# static_ip: "192.168.1.100"
+# gateway_ip: "192.168.1.1"
+# subnet_mask: "255.255.255.0"
+# dns1: "192.168.1.1"
 
 # DSMR Decryption Key (Luxembourg smartmeter)
 # Replace with your actual 32-character hex key


### PR DESCRIPTION
- Convert main YAML files into 'snippets' by removing boilerplate ESPHome config.
- Add instructional comments to YAMLs explaining the new copy-paste process.
- Remove confusing API, OTA, AP, and static IP keys from `secrets_template.yaml` as they are handled by the standard ESPHome setup.
- Completely rewrite README installation guide to be a clear, step-by-step process for novice users.