### PR TITLE
fix: Correct MQTT status topic in ESPHome config

### DIFF
--- a/enhanced_weigu_smartyreader_mqtt.yaml
+++ b/enhanced_weigu_smartyreader_mqtt.yaml
@@ -51,11 +51,11 @@ mqtt:
   
   # Birth and Will messages (like Arduino version)
   birth_message:
-    topic: ${mqtt_topic_prefix}/
+    topic: ${mqtt_topic_prefix}/status
     payload: "online"
     retain: true
   will_message:
-    topic: ${mqtt_topic_prefix}/  
+    topic: ${mqtt_topic_prefix}/status
     payload: "offline"
     retain: true
   


### PR DESCRIPTION
The `birth_message` and `will_message` topics in the MQTT configuration were incorrectly set to the root topic (`lamsmarty/`) instead of the documented status topic (`lamsmarty/status`).

This change corrects the topics to `${mqtt_topic_prefix}/status`, ensuring that the device's online and offline status is published to the correct MQTT topic, allowing for proper monitoring by Home Assistant and other clients.